### PR TITLE
close #37 embbed user data in access token

### DIFF
--- a/app/Services/AuthSV.php
+++ b/app/Services/AuthSV.php
@@ -43,12 +43,14 @@ class AuthSV
         }
 
         $guard = $role === 'user' ? 'api' : 'admin';
-
-        if (!$token = Auth::guard($guard)->attempt($credentials)) {
+        if (!$token = Auth::guard($guard)->claims([
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->role,
+        ])->attempt($credentials)) {
             return response()->json(['error' => 'Unauthorized'], 401);
         }
-
-        return $this->respondWithToken($token, $user, $guard);
+        return $this->respondWithToken($token, $guard);
     }
 
     /**
@@ -112,15 +114,12 @@ class AuthSV
     /**
      * Get the token array structure.
      */
-    protected function respondWithToken($token, $user = null, $role)
+    protected function respondWithToken($token, $guard)
     {
         return response()->json([
             'access_token' => $token,
             'token_type' => 'bearer',
-            'data' => [
-                'user' => $user,
-            ],
-            'expires_in_second' => Auth::guard($role)->factory()->getTTL() * 60
+            'expires_in_second' => Auth::guard($guard)->factory()->getTTL() * 60
         ]);
     }
 


### PR DESCRIPTION
## Before 

```
access_token:"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NjaGVkdWxpZnlhZG1pbi1wcm9kdWN0aW9uLnVwLnJhaWx3YXkuYXBwL2FwaS91c2VyL2xvZ2luIiwiaWF0IjoxNzQyMTg1NzYzLCJleHAiOjE3NDIxODYwNjMsIm5iZiI6MTc0MjE4NTc2MywianRpIjoiYmxSeG13MWUyZkEwTFdRTyIsInN1YiI6IjU2ZDJmMTA5LTU2MzgtNDU2NC05YzRhLWExNWQ4M2JlMWU0MCIsInBydiI6IjIzYmQ1Yzg5NDlmNjAwYWRiMzllNzAxYzQwMDg3MmRiN2E1OTc2ZjcifQ.nOEvDT9tBCDyJxUL-Ga_qYcZzNu7hOS9veywm79ZB4Y"
data: {user: {id: "56d2f109-5638-4564-9c4a-a15d83be1e40", name: "test", email: "test@gmail.com",…}}
user: {id: "56d2f109-5638-4564-9c4a-a15d83be1e40", name: "test", email: "test@gmail.com",…}
expires_in_second: 300
token_type: "bearer"

```

## After 

```
    "access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjgwMDAvYXBpL3VzZXIvbG9naW4iLCJpYXQiOjE3NDIxODU5NjIsImV4cCI6MTc0MjE4NjI2MiwibmJmIjoxNzQyMTg1OTYyLCJqdGkiOiIxOXVSQUk5TkhQMndXM3RDIiwic3ViIjoiNzg5ODEzZjYtYjMxYS00NzhlLTg2MmMtNGQ3OTdlMTNhZjdhIiwicHJ2IjoiMjNiZDVjODk0OWY2MDBhZGIzOWU3MDFjNDAwODcyZGI3YTU5NzZmNyIsIm5hbWUiOiJuYW5nZHlwYW5oYXIiLCJlbWFpbCI6Im5hbmdkeXBhbmhhckBnbWFpbC5jb20iLCJyb2xlIjoidXNlciJ9.5Sige4p6PRg4GOXXOoikcpzy58_OhN995QctwoVnQRc",
    "token_type": "bearer",
    "expires_in_second": 300


```

Description : Let return only access token and let the frontend decode the token to get the data instead